### PR TITLE
Fix bug when user enter a word not present in autocomplete values

### DIFF
--- a/js/jquery.pillbox.js
+++ b/js/jquery.pillbox.js
@@ -23,17 +23,21 @@
 				},
 
 				addAutoCompleteValue: function() {
-					var word = obj.currentHighlight.html();
+					if (obj.currentHighlight != undefined) {
+                        var word = obj.currentHighlight.html();
 
-					oSelf.values.push({
-						"key": word,
-						"value": obj.currentHighlight.attr("data-val")
-					});
+                        oSelf.values.push({
+                            "key": word,
+                            "value": obj.currentHighlight.attr("data-val")
+                        });
 
-					obj.addWord(word);
-					oSelf.autoComplete.hide();
-					oSelf.autoComplete.find(".pillbox-auto-suggest-item").removeClass("highlight");
-					delete obj.currentHighlight;
+                        obj.addWord(word);
+                        oSelf.autoComplete.hide();
+                        oSelf.autoComplete.find(".pillbox-auto-suggest-item").removeClass("highlight");
+                        delete obj.currentHighlight;
+                    } else {
+                        obj.addWord(oSelf.val());
+                    }
 				},
 
 				addWord: function(word) {


### PR DESCRIPTION
If you gave an autocomplete list to pillbox init for example : 

    [
        {"key" : "test", "value" : "test"},
        {"key" : "buzz", "value" : "buzz"}
    ]

and you wanted to add a pill like "test2", then there was an error.
Now you can add a pill which isn't in the autocomplete list.
